### PR TITLE
Fixed failing compilation with `serde::export`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 Project Changelog. Starts from version 0.2.1
 
+## [1.0.1] - 2021-13-04
+
+Minor bug fix.
+
+### Changed
+
+- Fixed failing compilation with `serde::export` ([change occured in this commit](https://github.com/serde-rs/serde/commit/dd1f4b483ee204d58465064f6e5bf5a457543b54))
+
 ## [1.0.0] - 2021-06-01
 
 Release V1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gql_client"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Arthur Khlghatyan <arthur.khlghatyan@gmail.com>"]
 edition = "2018"
 description = "Minimal GraphQL client for Rust"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use reqwest::Error;
-use serde::{export::Formatter, Deserialize};
+use serde::Deserialize;
+use std::fmt::Formatter;
 use std::collections::HashMap;
 use std::fmt;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,7 @@
 use reqwest::Error;
 use serde::Deserialize;
-use std::fmt::Formatter;
 use std::collections::HashMap;
-use std::fmt;
+use std::fmt::{self, Formatter};
 
 pub struct GraphQLError {
   message: String,


### PR DESCRIPTION
Hello!

Apparently at some point serde developers pushed [an update](https://github.com/serde-rs/serde/commit/dd1f4b483ee204d58465064f6e5bf5a457543b54) that discouraged the use of their private, uh, stuff, so the library stopped compiling 😢 

Luckily, after a quick google, it turned out to be a rather quick fix! [Here's another project](https://github.com/teloxide/teloxide/pull/329/commits/7ca96de4a72ee5c6befd7699e42ac7d2853a3a14) fixing this in the same way. All the tests pass, I checked 😉 

❤️ 