### PR TITLE
fix import of fmt::Formatter

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use reqwest::Error;
-use serde::{export::Formatter, Deserialize};
+use serde::Deserialize;
 use std::collections::HashMap;
-use std::fmt;
+use std::fmt::{self, Formatter};
 
 pub struct GraphQLError {
   message: String,


### PR DESCRIPTION
Previously was incorrectly importing a serde reexport, which was made private in newer versions, causing compilation errors:
```rust
error[E0603]: module `export` is private
    |
2   | use serde::{export::Formatter, Deserialize};
    |             ^^^^^^ private module
    |
note: the module `export` is defined here
    |
275 | use self::__private as export;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
```