### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vars = Vars { id: 1 };
     let data = client.query_with_vars::<Data, Vars>(query, vars).await.unwrap();
 
-    println!("Id: {}, Name: {}", data.user.id, data.user.name);
+    println!("Id: {}, Name: {}", data.unwrap().user.id, data.unwrap().user.name);
 
     Ok(())
 }


### PR DESCRIPTION
I found a mistake in the Example code listed in the README. 

```rust
let data = client.query_with_vars::<Data, Vars>(query, vars).await.unwrap();
```
Here `data` is an Option<Data>, so you need to call unwrap() to get user.id or user.name.

```diff
- println!("Id: {}, Name: {}", data.user.id, data.user.name);
+ println!("Id: {}, Name: {}", data.unwrap().user.id, data.unwrap().user.name);
```