### PR TITLE
add std::error::Error impl

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -101,3 +101,5 @@ impl From<Error> for GraphQLError {
     }
   }
 }
+
+impl std::error::Error for GraphQLError { }


### PR DESCRIPTION
This adds a trait implentation for the standard library error, which allows this to be much more easily integrated with error handling utilities like anyhow which require that trait.

The trait is empty because it just uses the existing `Display` trait, and all the other methods have default implementations and or are irrelevant.