### PR TITLE
Added optional rustls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "gql_client"
-version     = "1.0.7"
+version     = "1.0.8"
 authors     = ["Arthur Khlghatyan <arthur.khlghatyan@gmail.com>"]
 edition     = "2018"
 description = "Minimal GraphQL client for Rust"
@@ -14,10 +14,16 @@ categories  = ["web-programming", "asynchronous"]
 [badges]
 maintenance = { status = "actively-developed" }
 
+[features]
+default = ["native-tls"]
+
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+
 [dependencies]
 serde      = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest    = { version = "0.11", features = ["json"] }
+reqwest    = { version = "0.11", features = ["json"], default_features = false }
 log        = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
I added the ability to optionally use rustls over native-tls for the reqwest library's TLS by typing something like:
```
gql_client = { version = "1.0.8", default-features = false, features = ["rustls-tls"] }
```
for the project you want to use it in.

The original crate should work the exact same way as before if no features are used.