### PR TITLE
Add cookie support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 Project Changelog. Starts from version 0.2.1
 
+## [1.1.0] - 2024-28-03
+
+Add cookie support.
+
 ## [1.0.1] - 2021-13-04
 
 Minor bug fix.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 serde      = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest    = { version = "0.11", features = ["json"] }
+reqwest    = { version = "0.11", features = ["json", "cookies"] }
 log        = "0.4"
 
 [dev-dependencies]

--- a/Contributors.md
+++ b/Contributors.md
@@ -1,0 +1,4 @@
+git add Contributors.md# Contributors
+
+111111111111111111111111111111111
+- [Elon Aseneka Idiong'o](https://github.com/elonaire)


### PR DESCRIPTION
I added support for cookies on the reqwest client. They are disabled by default and some http requests need credentials to be allowed.

`reqwest    = { version = "0.11", features = ["json", "cookies"] }`