### PR TITLE
chore: bump reqwest from 0.11 to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 [dependencies]
 serde      = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest    = { version = "0.11", features = ["json"], default_features = false }
+reqwest    = { version = "0.12", features = ["json"], default_features = false }
 log        = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
`reqwest` is on `0.12` for almost a year now, this PR bumps de version.
(I made this PR as I use this library amongst many others and this is the only one that still uses 0.11)